### PR TITLE
fix: 更改docker-compose.yml 解决manager.jar连接mysql问题；映射配置文件

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - SPRING_DATASOURCE_DRUID_MAXACTIVE=20
       - SPRING_REDIS_HOST=endless-redis
     restart: always
+    volumes:
+      - ./app/config:/app/config # 映射文件以用于修改配置
     networks:
       - endless-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - endless-mysql
       - endless-redis
     environment:
-      - SPRING_DATASOURCE_DRUID_MASTER_URL=jdbc:mysql://endless-mysql:3306/minecraft_manager?useUnicode=true&characterEncoding=utf8&zeroDateTimeBehavior=convertToNull&useSSL=false&serverTimezone=GMT%2B8
+      - SPRING_DATASOURCE_DRUID_MASTER_URL=jdbc:mysql://endless-mysql:3306/minecraft_manager?useUnicode=true&characterEncoding=utf8&zeroDateTimeBehavior=convertToNull&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true
       - SPRING_DATASOURCE_DRUID_MASTER_USERNAME=root
       - SPRING_DATASOURCE_DRUID_MASTER_PASSWORD=password
       - SPRING_DATASOURCE_DRUID_INITIALSIZE=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,6 @@ services:
   endless-mysql:
     image: mysql:8.0.41
     container_name: endless-mysql
-    ports:
-      - "13306:3306"  # 将主机端口从3306改为13306
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: minecraft_manager
@@ -57,8 +55,6 @@ services:
   endless-redis:
     image: redis:6.0
     container_name: endless-redis
-    ports:
-      - "16379:6379"
     volumes:
       - redis-data:/data
     restart: always


### PR DESCRIPTION
## What this PR does

修改`docker-compose.yml`。  

去除不必要的端口暴露（`mysql`和`redis`）。  

解决启动`endless-manager.jar`的报错：`java.sql.SQLNonTransientConnectionException: Public Key Retrieval is not allowed`。

## Why this is needed

目前的`docker-compose.yml`还不能直接部署并开箱即用，还需要做修改。

## What was changed

对`docker-compose.yml`做了部分修改。  

- 删去`endless-mysql`和`endless-redis`不必要的端口暴露，因为其他容器可以使用<container name>:port访问
- `endless-server`的`environment`中第一个参数增加`&allowPublicKeyRetrieval=true`，安全性降低，但是这在docker内网中认为是可以接受的
- 映射`endless-server`的`/app/config/`到`./app/config/`便于第一次启动`endless-manager.jar`后修改配置

## Test

我通过上述修改成功部署服务。
