### PR TITLE
fix: docker一键部署优化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 使用支持 Java 8 的 Maven 镜像
-FROM maven:3.9.9-eclipse-temurin-8
+FROM maven:3.9.9-eclipse-temurin-8 AS build
 
 # 设置工作目录
 WORKDIR /app
@@ -21,7 +21,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /app
 
 # 复制jar包
-COPY --from=builder /app/endless-admin/target/endless-manager.jar ./app.jar
+COPY --from=build /app/endless-admin/target/endless-manager.jar ./app.jar
 
 # 暴露端口
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+# 使用支持 Java 8 的 Maven 镜像
+FROM maven:3.9.9-eclipse-temurin-8
+
+# 设置工作目录
+WORKDIR /app
+
+# 拷贝所有项目文件
+COPY . .
+
+# 编译并打包
+RUN mvn clean package
+
 FROM openjdk:8-jdk
 LABEL maintainer="EndlessManager"
 
@@ -9,10 +21,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /app
 
 # 复制jar包
-COPY ./endless-admin/target/endless-manager.jar ./app.jar
+COPY --from=builder /app/endless-admin/target/endless-manager.jar ./app.jar
 
 # 暴露端口
 EXPOSE 8080
 
 # 直接启动，不指定外部配置文件位置
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx1G", "-jar", "app.jar"]

--- a/endless-ui/Dockerfile
+++ b/endless-ui/Dockerfile
@@ -1,8 +1,30 @@
+# 编译静态文件
+FROM node:16 AS build
+
+# 设置工作目录
+WORKDIR /app
+
+# 复制 package.json
+COPY package*.json ./
+
+# 安装依赖
+RUN npm install
+
+# 复制所有源码
+COPY . .
+
+# 编译 Vue 项目
+RUN npm run build:prod
+
 FROM nginx:stable-alpine
 LABEL maintainer="EndlessManager"
 
-# 复制构建文件到nginx目录
-COPY dist/ /usr/share/nginx/html/
+# 删除默认的 nginx 主页
+RUN rm -rf /usr/share/nginx/html/*
+
+# 复制编译后的文件到 nginx 的 html 目录
+COPY --from=build /app/dist /usr/share/nginx/html
+
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # 暴露端口


### PR DESCRIPTION
## What this PR does

优化了docker部署，现在可以修改端口、mysql密码等配置后直接`docker-compose up -d`部署。

## Why this is needed

目前的docker一键部署还需要手动编译或下载`endless-mamger.jar`和`endless-ui`。

## What was changed

- 在`Dockerfile`中增加使用`maven:3.9.9-eclipse-temurin-8 AS build`编译`endless-mamger.jar`
- 在`endless-ui/Dockerfile`中增加使用`node:16 AS build`编译静态文件

## Test

```bash
# 修改docker-compose.yml 配置各服务端口、mysql密码等
# 一键部署
docker-compose up -d
# 之后还需要修改endless-server生成的配置
```

上述测试在我的服务器中完美部署
